### PR TITLE
Removed Development Check for Swagger

### DIFF
--- a/Pokepedia/Program.cs
+++ b/Pokepedia/Program.cs
@@ -10,11 +10,8 @@ builder.Services.AddSwaggerGen();
 var app = builder.Build();
 
 // Configure the HTTP request pipeline.
-if (app.Environment.IsDevelopment())
-{
-    app.UseSwagger();
-    app.UseSwaggerUI();
-}
+app.UseSwagger();
+app.UseSwaggerUI();
 
 app.UseHttpsRedirection();
 


### PR DESCRIPTION
I removed the check to see if the API is in development mode or release mode. We want the Swagger UI to be always on for now